### PR TITLE
Fixing careful use of mv so scripts will re-run correctly

### DIFF
--- a/scripts/install_client_with_git_to_linux
+++ b/scripts/install_client_with_git_to_linux
@@ -9,10 +9,10 @@ mkdir --parents $1/games
 mkdir --parents $1/worlds
 mkdir --parents $1/mods
 
-cp -R ../games/mcr_coderdojo $1/games/mcr_coderdojo
+cp -R ../games/mcr_coderdojo $1/games/
  
-cp -R ../worlds/Parade_Client_World $1/worlds/Parade_Client_World
+cp -R ../worlds/Parade_Client_World $1/worlds/
 
-cp -R ../mods/parade_local $1/mods/parade_local
+cp -R ../mods/parade_local $1/mods/
 
 echo Files copied to $1.  Please re-start Minetest to play

--- a/scripts/install_server_with_git_to_linux
+++ b/scripts/install_server_with_git_to_linux
@@ -7,7 +7,7 @@ fi
 
 # As currently written this script relys on the client script being installed first
 
-cp -R ../worlds/Parade_Server_World $1/worlds
-cp -R ../mods/parade_server $1/mods
+cp -R ../worlds/Parade_Server_World $1/worlds/
+cp -R ../mods/parade_server $1/mods/
 
 echo Files copied to $1.  Please re-start Minetest to play


### PR DESCRIPTION
Turns out I wasn't being very careful with my "mv" commands in the install scripts so they would work the first time but not re-run correctly.  Fixed it.
